### PR TITLE
Stretch - Showdown Results

### DIFF
--- a/Data/PodcastAPIDbContext.cs
+++ b/Data/PodcastAPIDbContext.cs
@@ -37,7 +37,17 @@ public class PodcastAPIDbContext : DbContext
             .HasForeignKey(p => p.UserId)
             .IsRequired();
 
-        modelBuilder.Entity<Episode>().HasData(EpisodeData.Episodes);
+        modelBuilder.Entity<Podcast>()
+            .HasMany<ShowdownResult>()
+            .WithOne()
+            .HasForeignKey(sr => sr.WinningPodcastId);
+
+        modelBuilder.Entity<Podcast>()
+            .HasMany<ShowdownResult>()
+            .WithOne()
+            .HasForeignKey(sr => sr.LosingPodcastId);
+
+modelBuilder.Entity<Episode>().HasData(EpisodeData.Episodes);
         modelBuilder.Entity<FavoriteEpisode>().HasData(FavoriteEpisodeData.FavoriteEpisodes);
         modelBuilder.Entity<FavoritePodcast>().HasData(FavoritePodcastData.FavoritePodcasts);
         modelBuilder.Entity<Genre>().HasData(GenreData.Genres);

--- a/Data/ShowdownResultsData.cs
+++ b/Data/ShowdownResultsData.cs
@@ -6,11 +6,11 @@ public class ShowdownResultsData
 {
     public static List<ShowdownResult> ShowdownResults = new()
     {
-        new() { Id = 1, WinningPodcastId = 1, LosingPodcastId = 5 },
-        new() { Id = 2, WinningPodcastId = 5, LosingPodcastId = 3 },
-        new() { Id = 3, WinningPodcastId = 5, LosingPodcastId = 4 },
-        new() { Id = 4, WinningPodcastId = 5, LosingPodcastId = 1 },
-        new() { Id = 5, WinningPodcastId = 2, LosingPodcastId = 3 }
+        new() { Id = 1, WinningPodcastId = 1, LosingPodcastId = 5, UserId = 1 },
+        new() { Id = 2, WinningPodcastId = 5, LosingPodcastId = 3, UserId = 2 },
+        new() { Id = 3, WinningPodcastId = 5, LosingPodcastId = 4, UserId = 3 },
+        new() { Id = 4, WinningPodcastId = 5, LosingPodcastId = 1, UserId = 4 },
+        new() { Id = 5, WinningPodcastId = 2, LosingPodcastId = 3, UserId = 1 }
     };
 }
 

--- a/Data/ShowdownResultsData.cs
+++ b/Data/ShowdownResultsData.cs
@@ -6,10 +6,10 @@ public class ShowdownResultsData
 {
     public static List<ShowdownResult> ShowdownResults = new()
     {
-        new() { Id = 1, WinningPodcastId = 1, LosingPodcastId = 5, UserId = 1 },
-        new() { Id = 2, WinningPodcastId = 5, LosingPodcastId = 3, UserId = 2 },
+        new() { Id = 1, WinningPodcastId = 1, LosingPodcastId = 5, UserId = 1, GenreId = 7 },
+        new() { Id = 2, WinningPodcastId = 5, LosingPodcastId = 3, UserId = 2, GenreId = 7 },
         new() { Id = 3, WinningPodcastId = 5, LosingPodcastId = 4, UserId = 3 },
-        new() { Id = 4, WinningPodcastId = 5, LosingPodcastId = 1, UserId = 4 },
+        new() { Id = 4, WinningPodcastId = 5, LosingPodcastId = 1, UserId = 4, GenreId = 7 },
         new() { Id = 5, WinningPodcastId = 2, LosingPodcastId = 3, UserId = 1 }
     };
 }

--- a/Endpoints/PodcastEndpoint.cs
+++ b/Endpoints/PodcastEndpoint.cs
@@ -178,6 +178,7 @@ public static class PodcastEndpoint
         })
         .WithOpenApi()
         .Produces<List<Podcast>>(StatusCodes.Status200OK);
+
         group.MapPost("/podcasts", async (IPodcastService podcastService, PodcastSubmitDTO podcastSubmit) =>
         {
             var addPodcast = await podcastService.CreatePodcastAsync(podcastSubmit);
@@ -197,7 +198,6 @@ public static class PodcastEndpoint
         .Produces<Podcast>(StatusCodes.Status201Created)
         .Produces(StatusCodes.Status404NotFound);
 
-        // Add comment
         group.MapPut("/podcasts/{podcastId}", async (IPodcastService podcastService, int podcastId, PodcastSubmitDTO podcastSubmit) =>
         {
             if (podcastSubmit.Id != podcastId)

--- a/Endpoints/ShowdownEndpoints.cs
+++ b/Endpoints/ShowdownEndpoints.cs
@@ -1,0 +1,10 @@
+﻿using System;
+namespace PodcastAPI.Endpoints;
+
+public static class ShowdownEndpoints
+{
+	public static void MapShowdownEndpoints(this IEndpointRouteBuilder routes)
+	{
+	}
+}
+

--- a/Endpoints/ShowdownEndpoints.cs
+++ b/Endpoints/ShowdownEndpoints.cs
@@ -60,6 +60,21 @@ public static class ShowdownEndpoints
             db.SaveChanges();
             return Results.Created();
         });
+
+        group.MapGet("/podcasts/showdown/{genreId}", (PodcastAPIDbContext db, int genreId, int userId) =>
+        {
+            if (!db.Genres.Any(g => g.Id == genreId))
+            {
+                return Results.NotFound("Genre id is not valid!");
+            }
+
+            if (!db.Users.Any(u => u.Id == userId))
+            {
+                return Results.NotFound("UserId is not valid!");
+            }
+
+            return Results.Ok();
+        });
     }
 }
 

--- a/Endpoints/ShowdownEndpoints.cs
+++ b/Endpoints/ShowdownEndpoints.cs
@@ -105,10 +105,10 @@ public static class ShowdownEndpoints
                 num *= i;
             }
 
-            // To be Fixed
+            // If there is no more comparisons that can be made
             if (showdownResults.Count >= num / denom)
             {
-                return Results.Ok("Message");
+                return Results.NoContent();
             }
 
             List<int> possibleIds = totalPodcasts.Where(tp => showdownResults.Count(sr => tp == sr.LosingPodcastId || tp == sr.WinningPodcastId) < totalPodcasts.Count - 1).ToList();

--- a/Endpoints/ShowdownEndpoints.cs
+++ b/Endpoints/ShowdownEndpoints.cs
@@ -1,10 +1,20 @@
 ﻿using System;
+using Microsoft.EntityFrameworkCore;
+using PodcastAPI.Data;
+using PodcastAPI.Models;
+
 namespace PodcastAPI.Endpoints;
 
 public static class ShowdownEndpoints
 {
 	public static void MapShowdownEndpoints(this IEndpointRouteBuilder routes)
 	{
-	}
+        var group = routes.MapGroup("").WithTags(nameof(ShowdownResult));
+
+        group.MapPost("/showdown", (PodcastAPIDbContext db, ShowdownResult showdownResult) =>
+        {
+            
+        });
+    }
 }
 

--- a/Migrations/20241102151611_ManyToManyShowdownResult.Designer.cs
+++ b/Migrations/20241102151611_ManyToManyShowdownResult.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using PodcastAPI.Data;
@@ -11,9 +12,10 @@ using PodcastAPI.Data;
 namespace PodcastAPI.Migrations
 {
     [DbContext(typeof(PodcastAPIDbContext))]
-    partial class PodcastAPIDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241102151611_ManyToManyShowdownResult")]
+    partial class ManyToManyShowdownResult
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20241102151611_ManyToManyShowdownResult.cs
+++ b/Migrations/20241102151611_ManyToManyShowdownResult.cs
@@ -1,0 +1,103 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PodcastAPI.Migrations
+{
+    public partial class ManyToManyShowdownResult : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "UserId",
+                table: "ShowdownResults",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.UpdateData(
+                table: "ShowdownResults",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "UserId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "ShowdownResults",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "UserId",
+                value: 2);
+
+            migrationBuilder.UpdateData(
+                table: "ShowdownResults",
+                keyColumn: "Id",
+                keyValue: 3,
+                column: "UserId",
+                value: 3);
+
+            migrationBuilder.UpdateData(
+                table: "ShowdownResults",
+                keyColumn: "Id",
+                keyValue: 4,
+                column: "UserId",
+                value: 4);
+
+            migrationBuilder.UpdateData(
+                table: "ShowdownResults",
+                keyColumn: "Id",
+                keyValue: 5,
+                column: "UserId",
+                value: 1);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ShowdownResults_LosingPodcastId",
+                table: "ShowdownResults",
+                column: "LosingPodcastId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ShowdownResults_WinningPodcastId",
+                table: "ShowdownResults",
+                column: "WinningPodcastId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ShowdownResults_Podcasts_LosingPodcastId",
+                table: "ShowdownResults",
+                column: "LosingPodcastId",
+                principalTable: "Podcasts",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ShowdownResults_Podcasts_WinningPodcastId",
+                table: "ShowdownResults",
+                column: "WinningPodcastId",
+                principalTable: "Podcasts",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_ShowdownResults_Podcasts_LosingPodcastId",
+                table: "ShowdownResults");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ShowdownResults_Podcasts_WinningPodcastId",
+                table: "ShowdownResults");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ShowdownResults_LosingPodcastId",
+                table: "ShowdownResults");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ShowdownResults_WinningPodcastId",
+                table: "ShowdownResults");
+
+            migrationBuilder.DropColumn(
+                name: "UserId",
+                table: "ShowdownResults");
+        }
+    }
+}

--- a/Migrations/20241102161855_AddGenreIdToShowdown.Designer.cs
+++ b/Migrations/20241102161855_AddGenreIdToShowdown.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using PodcastAPI.Data;
@@ -11,9 +12,10 @@ using PodcastAPI.Data;
 namespace PodcastAPI.Migrations
 {
     [DbContext(typeof(PodcastAPIDbContext))]
-    partial class PodcastAPIDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241102161855_AddGenreIdToShowdown")]
+    partial class AddGenreIdToShowdown
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20241102161855_AddGenreIdToShowdown.cs
+++ b/Migrations/20241102161855_AddGenreIdToShowdown.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PodcastAPI.Migrations
+{
+    public partial class AddGenreIdToShowdown : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "GenreId",
+                table: "ShowdownResults",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.UpdateData(
+                table: "ShowdownResults",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "GenreId",
+                value: 7);
+
+            migrationBuilder.UpdateData(
+                table: "ShowdownResults",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "GenreId",
+                value: 7);
+
+            migrationBuilder.UpdateData(
+                table: "ShowdownResults",
+                keyColumn: "Id",
+                keyValue: 3,
+                column: "GenreId",
+                value: -1);
+
+            migrationBuilder.UpdateData(
+                table: "ShowdownResults",
+                keyColumn: "Id",
+                keyValue: 4,
+                column: "GenreId",
+                value: 7);
+
+            migrationBuilder.UpdateData(
+                table: "ShowdownResults",
+                keyColumn: "Id",
+                keyValue: 5,
+                column: "GenreId",
+                value: -1);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "GenreId",
+                table: "ShowdownResults");
+        }
+    }
+}

--- a/Models/ShowdownResult.cs
+++ b/Models/ShowdownResult.cs
@@ -7,6 +7,7 @@ namespace PodcastAPI.Models
         public int WinningPodcastId { get; set; }
         public int LosingPodcastId { get; set; }
         public int UserId { get; set; }
+        public int GenreId { get; set; } = -1;
     }
 }
 

--- a/Models/ShowdownResult.cs
+++ b/Models/ShowdownResult.cs
@@ -6,6 +6,7 @@ namespace PodcastAPI.Models
         public int Id { get; set; }
         public int WinningPodcastId { get; set; }
         public int LosingPodcastId { get; set; }
+        public int UserId { get; set; }
     }
 }
 

--- a/Program.cs
+++ b/Program.cs
@@ -58,5 +58,6 @@ app.MapEpisodeEndpoints();
 app.MapPodcastEndpoints();
 app.MapGenreEndpoints();
 app.MapUserEndpoints();
+app.MapShowdownEndpoints();
 
 app.Run();


### PR DESCRIPTION
# Description

- Had to rework the Showdown Model and Mock dat to include the userId and genreId
- Edited the DbContext file so the Showdown Model can do cascade delete if a Podcast is deleted and the ids are linked to the Podcast id
- Created an API to create a showdown entry for when a user chooses a one of two podcasts options
- Created an API to get two podcasts for user to vote on