### PR TITLE
Added GenreId logic to /showdown POST

### DIFF
--- a/Endpoints/ShowdownEndpoints.cs
+++ b/Endpoints/ShowdownEndpoints.cs
@@ -53,7 +53,8 @@ public static class ShowdownEndpoints
             {
                 WinningPodcastId = showdownResult.WinningPodcastId,
                 LosingPodcastId = showdownResult.LosingPodcastId,
-                UserId = showdownResult.UserId
+                UserId = showdownResult.UserId,
+                GenreId = winningPodcast.GenreId == losingPodcast.GenreId ? winningPodcast.GenreId : -1
             };
 
             db.ShowdownResults.Add(newShowdownResult);


### PR DESCRIPTION
When adding a showdown via /showdown endpoint, genreId is automatically calculated to be the genre from the podcasts if they are equal, and -1 if the podcasts are not from the same genre.