### PR TITLE
Big Fix in Getting Two Podcast for Showdown

### DIFF
--- a/Endpoints/ShowdownEndpoints.cs
+++ b/Endpoints/ShowdownEndpoints.cs
@@ -79,7 +79,7 @@ public static class ShowdownEndpoints
 
             if (totalPodcasts.Count < 2)
             {
-                return Results.Content("There are not enough podcasts in this genre.");
+                return Results.Ok("There are not enough podcasts in this genre.");
             }
 
             List<ShowdownResult> showdownResults = db.ShowdownResults


### PR DESCRIPTION
# Description
Changed how the message that returns when the podcasts in genre is less than 2 because it was returning code verses a string.